### PR TITLE
fix compat for 5.5 ish kernel

### DIFF
--- a/ovos-i2csound
+++ b/ovos-i2csound
@@ -58,6 +58,17 @@ get_board_version() {
         fi
     done
 }
+
+# Checks for kernal compat
+compare_kernel_version() {
+    current_kernel=$(uname -r | sed -re 's/(^[0-9]*\.[0-9]*\.[0-9]*-[0-9]*)(.*)/\1/')
+    if [[ "$current_kernel" < "$1" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Main execution
 main() {
 
@@ -189,11 +200,18 @@ main() {
     if [[ ${detection_results[TAS5806]} == true ]] ; then
         echo "Installing and configuring SJ-201 HAT"
         # Initializing XMOS xvf3510
-        if [[ "$board_result" == "RPI5" ]]; then
-            dtoverlay sj201-pi5
+
+        # Check for kernel version
+        if $(compare_kernel_version "6.6"); then
+            dtoverlay xvf3510
         else
-            dtoverlay sj201
+            if [[ "$board_result" == "RPI5" ]]; then
+                dtoverlay sj201-pi5
+            else
+                dtoverlay sj201
+            fi
         fi
+
         /usr/libexec/xvf3510-flash --direct "/usr/lib/firmware/xvf3510/app_xvf3510_int_spi_boot_v4_1_0.bin"
         # Initializing Texas Instruments 5806 Amplifier
         /usr/bin/tas5806-init


### PR DESCRIPTION
was mentioned [here](https://github.com/OpenVoiceOS/ovos-i2csound/pull/11#discussion_r1548649942) about backwards compatibility 