### PR TITLE
fix: moved i2c_platform file to user agnostic directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,15 @@ Place the following files in the respective directory, and reboot your system.
 `ovos-i2csound` -> `/usr/libexec/ovos-i2csound`
 `99-i2c.rules` -> `/usr/lib/udev/rules.d/99-i2c.rules`
 
+
+## Usage
+
+When installed and enabled, this script will run at boot time and try to detect the attached card if any.  If a supported card is detected, ovos-i2csound will setup Alsa to the correct values for that card.
+
+Also, as an added feature, when a card is detected, a file will be created at `/etc/OpenVoiceOS/i2c_platform`.  It contains a single line with the name of the card detected.
+
+This file can be read and used as validation for plugins, or any other use you may find.
+
+If the file does not exist, ovos-i2csound ran, but did not find a supported card.
+
 Issues can be made [here](https://github.com/OpenVoiceOS/ovos-i2csound/issues/)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Place the following files in the respective directory, and reboot your system.
 `ovos-i2csound` -> `/usr/libexec/ovos-i2csound`
 `99-i2c.rules` -> `/usr/lib/udev/rules.d/99-i2c.rules`
 
+Create the directory for ovos-i2csound to store a variable in
+`sudo mkdir /etc/OpenVoiceOS`
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,9 @@ main() {
     copy_file "$PWD/ovos-i2csound" "$script_dir/ovos-i2csound"
     chmod +x "${script_dir}/ovos-i2csound"
     systemctl enable i2c_platform.service
+    if [[ ! -d /etc/OpenVoiceOS ]]; then
+        mkdir /etc/OpenVoiceOS
+    fi
     echo "Installation complete. Please reboot your system to apply changes."
     }
 # Check for root privileges

--- a/ovos-i2csound
+++ b/ovos-i2csound
@@ -73,7 +73,7 @@ compare_kernel_version() {
 main() {
     # Create a variable to hold the detected device name
     local i2c_device_name
-    local i2c_device_file=/etc/mycroft/i2c_platform
+    local i2c_device_file=$HOME/.config/mycroft/i2c_platform
 
     # Check for an existing file and remove it if there
     if [[ -f $i2c_device_file ]]; then

--- a/ovos-i2csound
+++ b/ovos-i2csound
@@ -73,10 +73,11 @@ compare_kernel_version() {
 main() {
     # Create a variable to hold the detected device name
     local i2c_device_name
+    local i2c_device_file=/etc/mycroft/i2c_platform
 
     # Check for an existing file and remove it if there
-    if [[ -f /home/ovos/.config/mycroft/i2c_platform ]]; then
-        rm -f /home/ovos/.config/mycroft/i2c_platform
+    if [[ -f $i2c_device_file ]]; then
+        rm -f $i2c_device_file
     fi
 
     get_board_version
@@ -295,7 +296,7 @@ fi
 
     # Write the detection results to a file only if something is detected
     if [ "$i2c_device_name" ]; then
-        echo "$i2c_device_name" > /home/ovos/.config/mycroft/i2c_platform
+        echo "$i2c_device_name" > $i2c_device_file
     fi
 }
 

--- a/ovos-i2csound
+++ b/ovos-i2csound
@@ -296,7 +296,9 @@ fi
 
     # Write the detection results to a file only if something is detected
     if [ "$i2c_device_name" ]; then
-        echo "$i2c_device_name" > $i2c_device_file
+        if [[ -d dirname $i2c_device_file ]]; then
+            echo "$i2c_device_name" > $i2c_device_file
+        fi
     fi
 }
 

--- a/ovos-i2csound
+++ b/ovos-i2csound
@@ -73,7 +73,7 @@ compare_kernel_version() {
 main() {
     # Create a variable to hold the detected device name
     local i2c_device_name
-    local i2c_device_file=$HOME/.config/mycroft/i2c_platform
+    local i2c_device_file="/etc/OpenVoiceOS/i2c_platform"
 
     # Check for an existing file and remove it if there
     if [[ -f $i2c_device_file ]]; then


### PR DESCRIPTION
It was mentioned [here](https://github.com/OpenVoiceOS/ovos-i2csound/pull/9#discussion_r1586948189) that this only works for user `ovos`.  This moves the `i2c_platform` file to `/etc/mycroft/i2c_platform` to not hard code a user.

It was mentioned to set an environment file, but those can only be set for the current shell, or on a reboot.  System environment variables CAN NOT be set dynamically according to everything I have read.