### PR TITLE
fix: mark1 default sink

### DIFF
--- a/ovos-i2csound
+++ b/ovos-i2csound
@@ -104,21 +104,6 @@ check_mark_1() {
     return 1
 }
 
-# Make the mk1 soundcard the default
-set_default_sink_mark_1() {
-  MK1_CARD_NAME="snd_rpi_proto"
-
-  # Step 1: Extract the card name or identifier
-  CARD_NUMBER=$(aplay -l | grep "$MK1_CARD_NAME" | awk '{print $2}' | cut -d':' -f1)
-  echo "Card number: $CARD_NUMBER"
-
-  # Step 2: Set ALSA default sound card
-  # Update the default ALSA configuration to use the MK1 card
-  echo "defaults.pcm.card $CARD_NUMBER" > /etc/asound.conf
-  echo "defaults.ctl.card $CARD_NUMBER" >> /etc/asound.conf
-  echo "ALSA default card set to: $CARD_NUMBER"
-}
-
 # Main execution
 main() {
     # Create a variable to hold the detected device name
@@ -205,8 +190,12 @@ main() {
         echo "eyes.color=7365993" > /dev/ttyAMA0  # color=soft gray, #706569
         echo "mouth.text=" > /dev/ttyAMA0
         i2c_device_name="MARK1"
-
-        set_default_sink_mark_1
+        MK1_CARD_NAME="snd_rpi_proto"
+        CARD_NUMBER=$(aplay -l | grep "$MK1_CARD_NAME" | awk '{print $2}' | cut -d':' -f1)
+        # Update the default ALSA configuration to use the MK1 card
+        echo "defaults.pcm.card $CARD_NUMBER" > /etc/asound.conf
+        echo "defaults.ctl.card $CARD_NUMBER" >> /etc/asound.conf
+        echo "ALSA default card set to: $CARD_NUMBER"
     fi
 
     if [[ ${detection_results[RESPEAKER4]} == true ]] && [[ ${detection_results[RESPEAKER6]} == false ]] ; then

--- a/ovos-i2csound
+++ b/ovos-i2csound
@@ -109,22 +109,14 @@ set_default_sink_mark_1() {
   MK1_CARD_NAME="snd_rpi_proto"
 
   # Step 1: Extract the card name or identifier
-  CARD_INFO=$(aplay -l | grep "$MK1_CARD_NAME" | awk '{print $2}')
-  echo "Card info: $CARD_INFO"
+  CARD_NUMBER=$(aplay -l | grep "$MK1_CARD_NAME" | awk '{print $2}' | cut -d':' -f1)
+  echo "Card number: $CARD_NUMBER"
 
-  # Step 2: Set the default sink name
-  MK1_SINK_NAME="alsa_output.platform-soc_sound.stereo-fallback"
-
-  # Step 3: Check if pactl is available
-  if command -v pactl > /dev/null 2>&1; then
-      # Step 4: Set the default sink if the card was found
-      if [ -n "$CARD_INFO" ]; then
-          pactl set-default-sink "$MK1_SINK_NAME"
-          echo "Default sink set to: $MK1_SINK_NAME"
-      else
-          echo "No matching card found for: $MK1_CARD_NAME"
-      fi
-  fi
+  # Step 2: Set ALSA default sound card
+  # Update the default ALSA configuration to use the MK1 card
+  echo "defaults.pcm.card $CARD_NUMBER" > /etc/asound.conf
+  echo "defaults.ctl.card $CARD_NUMBER" >> /etc/asound.conf
+  echo "ALSA default card set to: $CARD_NUMBER"
 }
 
 # Main execution

--- a/ovos-i2csound
+++ b/ovos-i2csound
@@ -104,6 +104,29 @@ check_mark_1() {
     return 1
 }
 
+# Make the mk1 soundcard the default
+set_default_sink_mark_1() {
+  MK1_CARD_NAME="snd_rpi_proto"
+
+  # Step 1: Extract the card name or identifier
+  CARD_INFO=$(aplay -l | grep "$MK1_CARD_NAME" | awk '{print $2}')
+  echo "Card info: $CARD_INFO"
+
+  # Step 2: Set the default sink name
+  MK1_SINK_NAME="alsa_output.platform-soc_sound.stereo-fallback"
+
+  # Step 3: Check if pactl is available
+  if command -v pactl > /dev/null 2>&1; then
+      # Step 4: Set the default sink if the card was found
+      if [ -n "$CARD_INFO" ]; then
+          pactl set-default-sink "$MK1_SINK_NAME"
+          echo "Default sink set to: $MK1_SINK_NAME"
+      else
+          echo "No matching card found for: $MK1_CARD_NAME"
+      fi
+  fi
+}
+
 # Main execution
 main() {
     # Create a variable to hold the detected device name
@@ -190,6 +213,8 @@ main() {
         echo "eyes.color=7365993" > /dev/ttyAMA0  # color=soft gray, #706569
         echo "mouth.text=" > /dev/ttyAMA0
         i2c_device_name="MARK1"
+
+        set_default_sink_mark_1
     fi
 
     if [[ ${detection_results[RESPEAKER4]} == true ]] && [[ ${detection_results[RESPEAKER6]} == false ]] ; then


### PR DESCRIPTION
while mk1 is properly detected in raspOVOS it is not selected by default resulting in no audio out

related https://github.com/OpenVoiceOS/raspOVOS/pull/127 tries to workaround this issue, but for know boards it's preferable to not have a combined sink

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added automatic audio sink configuration for Mark-1 sound card
	- Enhanced audio setup process with device-specific detection and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->